### PR TITLE
changed ndof cut for vertices with BS constraint

### DIFF
--- a/PrimaryVertexAnalyzer/src/PrimaryVertexAnalyzer4PU.cc
+++ b/PrimaryVertexAnalyzer/src/PrimaryVertexAnalyzer4PU.cc
@@ -199,7 +199,7 @@ PrimaryVertexAnalyzer4PU::PrimaryVertexAnalyzer4PU(const ParameterSet& iConfig)
   fill_track_histos_ = iConfig.getUntrackedParameter<bool>("fill_track_histos", false);
   selNdofNoBS_ = iConfig.getUntrackedParameter<double>("selNdof", 4.);
   std::cout << "selNDof_(noBS) = " << selNdofNoBS_ << std::endl;
-  selNdofWithBS_ = iConfig.getUntrackedParameter<double>("selNdofWithBS", 2.);
+  selNdofWithBS_ = iConfig.getUntrackedParameter<double>("selNdofWithBS", 7.);
   std::cout << "selNDofWithBS_ = " << selNdofWithBS_ << std::endl;
   selNdof_ = selNdofNoBS_; // to be changed later according to the collection name
   ndof0trk_ = 0.;

--- a/PrimaryVertexAnalyzer/test/cfg/pv3_cfg.py
+++ b/PrimaryVertexAnalyzer/test/cfg/pv3_cfg.py
@@ -49,7 +49,7 @@ vcollections = ["offlinePrimaryVertices", "offlinePrimaryVerticesWithBS"]
 parameters={  # can be overwritten by arguments of the same name
   "4D": cms.untracked.bool(False),
   "selNdof": cms.untracked.double(4.0),
-  "selNdofWithBS": cms.untracked.double(2.0),
+  "selNdofWithBS": cms.untracked.double(7.0),
 #  "splitmethod":cms.untracked.int32(0),
   "usefit":cms.untracked.bool(False),
   "use_tp":cms.untracked.bool(False),

--- a/PrimaryVertexAnalyzer/test/cfg/pvt_cfg.py
+++ b/PrimaryVertexAnalyzer/test/cfg/pvt_cfg.py
@@ -54,7 +54,7 @@ vcollections = ["offlinePrimaryVertices", "offlinePrimaryVerticesWithBS"]
 parameters={  # can be overwritten by arguments of the same name
   "4D": cms.untracked.bool(False),
   "selNdof": cms.untracked.double(4.0),
-  "selNdofWithBS": cms.untracked.double(2.0),
+  "selNdofWithBS": cms.untracked.double(7.0),
 #  "splitmethod":cms.untracked.int32(0),
   "usefit":cms.untracked.bool(False),
   "use_tp":cms.untracked.bool(False),


### PR DESCRIPTION
Ndof cut for vertices with beamspot constraint increased from 2 to 7, to match the cut of 4 used for vertices w/o BS constraint.

For reference, here are some relevant links for the computation of the PVs' ndof in CMSSW:
* [PrimaryVertexProducer::bsToken](https://github.com/cms-sw/cmssw/blob/99c1844603c1457b47601d9c67d1935e90e40fa6/RecoVertex/PrimaryVertexProducer/plugins/PrimaryVertexProducer.cc#L23)
* [PrimaryVertexProducer, validBS](https://github.com/cms-sw/cmssw/blob/99c1844603c1457b47601d9c67d1935e90e40fa6/RecoVertex/PrimaryVertexProducer/plugins/PrimaryVertexProducer.cc#L155)
* [PrimaryVertexProducer, BS-constrained PV fit](https://github.com/cms-sw/cmssw/blob/99c1844603c1457b47601d9c67d1935e90e40fa6/RecoVertex/PrimaryVertexProducer/plugins/PrimaryVertexProducer.cc#L245)
* [AdaptiveVertexFitter::vertex](https://github.com/cms-sw/cmssw/blob/99c1844603c1457b47601d9c67d1935e90e40fa6/RecoVertex/AdaptiveVertexFit/src/AdaptiveVertexFitter.cc#L186-L187)
* [AdaptiveVertexFitter::fit](https://github.com/cms-sw/cmssw/blob/99c1844603c1457b47601d9c67d1935e90e40fa6/RecoVertex/AdaptiveVertexFit/src/AdaptiveVertexFitter.cc#L462-L465)
* [CachingVertex<N>::computeNDF()](https://github.com/cms-sw/cmssw/blob/99c1844603c1457b47601d9c67d1935e90e40fa6/RecoVertex/VertexPrimitives/src/CachingVertex.cc#L355)