### PR TITLE
converted `PrimaryVertexAnalyzer4PU` to "One" module

### DIFF
--- a/PrimaryVertexAnalyzer/interface/PrimaryVertexAnalyzer4PU.h
+++ b/PrimaryVertexAnalyzer/interface/PrimaryVertexAnalyzer4PU.h
@@ -38,7 +38,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 
@@ -126,7 +126,7 @@ typedef ROOT::Math::PositionVector3D<ROOT::Math::Cartesian3D<float>,ROOT::Math::
 typedef reco::Vertex::trackRef_iterator trackit_t;
 
 // class declaration
-class PrimaryVertexAnalyzer4PU : public edm::EDAnalyzer {
+class PrimaryVertexAnalyzer4PU : public edm::one::EDAnalyzer<> {
   typedef math::XYZTLorentzVector LorentzVector;
   typedef reco::TrackBase::ParameterVector ParameterVector;
 


### PR DESCRIPTION
This is the simplest way to avoid using the "legacy" module type `edm::EDAnalyzer`, which will soon be deprecated.

The relevant TWikis are [[1]](https://twiki.cern.ch/twiki/bin/view/CMSPublic/FWMultithreadedFrameworkModuleTypes) and [[2]](https://twiki.cern.ch/twiki/bin/view/CMSPublic/FWMultithreadedFrameworkOneModuleInterface).

In the future, it might be possible to convert the plugin to ["Stream"](https://twiki.cern.ch/twiki/bin/view/CMSPublic/FWMultithreadedFrameworkStreamModuleInterface) or ["Global"](https://twiki.cern.ch/twiki/bin/view/CMSPublic/FWMultithreadedFrameworkGlobalModuleInterface) (for better performance with multi-threading), but that requires a bit more work.