### PR TITLE
prototype of standalone workflow for vertex-time computation

### DIFF
--- a/PrimaryVertexAnalyzer/plugins/BuildFile.xml
+++ b/PrimaryVertexAnalyzer/plugins/BuildFile.xml
@@ -1,0 +1,9 @@
+<library name="usercodePrimaryVertexAnalyzerPlugins" file="*.cc">
+  <flags EDM_PLUGIN="1"/>
+  <use name="FWCore/Framework"/>
+  <use name="FWCore/ParameterSet"/>
+  <use name="FWCore/MessageLogger"/>
+  <use name="CommonTools/Utils"/>
+  <use name="CommonTools/UtilAlgos"/>
+  <use name="DataFormats/VertexReco"/>
+</library>

--- a/PrimaryVertexAnalyzer/plugins/VertexTimeAnalyzer.cc
+++ b/PrimaryVertexAnalyzer/plugins/VertexTimeAnalyzer.cc
@@ -1,0 +1,142 @@
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "CommonTools/UtilAlgos/interface/TFileService.h"
+#include "DataFormats/VertexReco/interface/Vertex.h"
+#include "DataFormats/VertexReco/interface/VertexFwd.h"
+#include "DataFormats/TrackReco/interface/Track.h"
+#include "DataFormats/TrackReco/interface/TrackFwd.h"
+
+#include <memory>
+#include <string>
+#include <unordered_map>
+
+#include <TH1D.h>
+
+#ifdef PVTX_DEBUG
+#define LOG edm::Print("VertexTimeAnalyzer")
+#else
+#define LOG LogDebug("VertexTimeAnalyzer")
+#endif
+
+class VertexTimeAnalyzer : public edm::one::EDAnalyzer<edm::one::SharedResources> {
+public:
+  explicit VertexTimeAnalyzer(edm::ParameterSet const&);
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+private:
+  void analyze(const edm::Event &, const edm::EventSetup &) override;
+
+  edm::InputTag const vtx_tag_;
+  edm::EDGetTokenT<edm::View<reco::Vertex>> const vtx_token_;
+
+  int const maxNumberOfVertices_;
+  std::string const histogramNamePrefix_;
+
+  edm::ParameterSet const histogramPSet_;
+
+  typedef edm::ValueMap<float> edmVMapType;
+
+  struct vMapEntry {
+    std::string name;
+    edm::EDGetTokenT<edmVMapType> token;
+    edm::Handle<edmVMapType> vmapHandle;
+  };
+
+  std::unordered_map<std::string, TH1D*> h1map_;
+  std::vector<vMapEntry> vmapVec_;
+};
+
+VertexTimeAnalyzer::VertexTimeAnalyzer(const edm::ParameterSet &iConfig)
+    : vtx_tag_(iConfig.getParameter<edm::InputTag>("vertices")),
+      vtx_token_(consumes(vtx_tag_)),
+      maxNumberOfVertices_(iConfig.getParameter<int>("maxNumberOfVertices")),
+      histogramNamePrefix_(iConfig.getParameter<std::string>("histogramNamePrefix")),
+      histogramPSet_(iConfig.getParameter<edm::ParameterSet>("histogramPSet")) {
+  usesResource(TFileService::kSharedResource);
+
+  edm::Service<TFileService> fs;
+
+  if (not fs) {
+    throw cms::Exception("Configuration") << "TFileService is not registered in cfg file";
+  }
+
+  h1map_.clear();
+
+  h1map_["mult"] = fs->make<TH1D>((histogramNamePrefix_+"mult").c_str(), (histogramNamePrefix_+"mult").c_str(), 300, 0, 300);
+  h1map_["x"] = fs->make<TH1D>((histogramNamePrefix_+"x").c_str(), (histogramNamePrefix_+"x").c_str(), 600, -0.1, 0.1);
+  h1map_["y"] = fs->make<TH1D>((histogramNamePrefix_+"y").c_str(), (histogramNamePrefix_+"y").c_str(), 600, -0.1, 0.1);
+  h1map_["z"] = fs->make<TH1D>((histogramNamePrefix_+"z").c_str(), (histogramNamePrefix_+"z").c_str(), 600, -30, 30);
+  h1map_["t"] = fs->make<TH1D>((histogramNamePrefix_+"t").c_str(), (histogramNamePrefix_+"t").c_str(), 600, -30, 30);
+  h1map_["tError"] = fs->make<TH1D>((histogramNamePrefix_+"tError").c_str(), (histogramNamePrefix_+"tError").c_str(), 600, 0, 30);
+  h1map_["normChi2"] = fs->make<TH1D>((histogramNamePrefix_+"normChi2").c_str(), (histogramNamePrefix_+"normChi2").c_str(), 600, 0, 12);
+  h1map_["ndof"] = fs->make<TH1D>((histogramNamePrefix_+"ndof").c_str(), (histogramNamePrefix_+"ndof").c_str(), 120, 0, 480);
+  h1map_["nTracks"] = fs->make<TH1D>((histogramNamePrefix_+"nTracks").c_str(), (histogramNamePrefix_+"nTracks").c_str(), 120, 0, 480);
+
+  auto const& histogramPSetNames = histogramPSet_.getParameterNamesForType<edm::ParameterSet>();
+  vmapVec_.clear();
+  vmapVec_.reserve(histogramPSetNames.size());
+  for(auto const& psetName : histogramPSetNames){
+    auto const hname = histogramNamePrefix_+psetName;
+    auto const& pset = histogramPSet_.getParameter<edm::ParameterSet>(psetName);
+    auto const nbins = pset.getParameter<uint>("nbins");
+    auto const xmin = pset.getParameter<double>("xmin");
+    auto const xmax = pset.getParameter<double>("xmax");
+    h1map_[psetName] = fs->make<TH1D>(hname.c_str(), hname.c_str(), nbins, xmin, xmax);
+    vmapVec_.emplace_back();
+    vmapVec_.back().name = psetName;
+    vmapVec_.back().token = consumes(pset.getParameter<edm::InputTag>("valueMapTag"));
+  }
+}
+
+void VertexTimeAnalyzer::analyze(const edm::Event &iEvent, const edm::EventSetup &iSetup) {
+  auto const& vertices = iEvent.getHandle(vtx_token_);
+
+  if (vertices.isValid()) {
+
+    for(auto& vmap_i : vmapVec_){
+      vmap_i.vmapHandle = iEvent.getHandle(vmap_i.token);
+    }
+
+    auto const vtxMax = maxNumberOfVertices_ < 0 ? vertices->size() : std::min(vertices->size(), uint(maxNumberOfVertices_));
+    h1map_["mult"]->Fill(vtxMax);
+
+    for (uint idx = 0; idx < vtxMax; ++idx) {
+      auto const& vtx = (*vertices)[idx];
+
+      h1map_["x"]->Fill(vtx.x());
+      h1map_["y"]->Fill(vtx.y());
+      h1map_["z"]->Fill(vtx.z());
+      h1map_["t"]->Fill(vtx.t());
+      h1map_["tError"]->Fill(vtx.tError());
+      h1map_["normChi2"]->Fill(vtx.normalizedChi2());
+      h1map_["ndof"]->Fill(vtx.ndof());
+      h1map_["nTracks"]->Fill(vtx.nTracks());
+
+      for(auto const& vmap_i : vmapVec_){
+        h1map_[vmap_i.name]->Fill((*vmap_i.vmapHandle)[vertices->ptrAt(idx)]);
+      }
+    }
+  } else {
+    edm::LogWarning("Input") << "invalid handle to reco::VertexCollection : " << vtx_tag_.encode();
+  }
+}
+
+void VertexTimeAnalyzer::fillDescriptions(edm::ConfigurationDescriptions &descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<edm::InputTag>("vertices", edm::InputTag("offlinePrimaryVertices"))->setComment("edm::InputTag of reco::VertexCollection");
+  desc.add<int>("maxNumberOfVertices", -1)->setComment("max of number of vertices used to fill histograms");
+  desc.add<std::string>("histogramNamePrefix", "vertex_")->setComment("prefix for names of all output histograms");
+
+  edm::ParameterSetDescription histogramPSetDesc;
+  histogramPSetDesc.setAllowAnything();
+  desc.add<edm::ParameterSetDescription>("histogramPSet", histogramPSetDesc);
+
+  descriptions.addWithDefaultLabel(desc);
+}
+
+DEFINE_FWK_MODULE(VertexTimeAnalyzer);

--- a/PrimaryVertexAnalyzer/plugins/VertexTimeProducer.cc
+++ b/PrimaryVertexAnalyzer/plugins/VertexTimeProducer.cc
@@ -1,0 +1,332 @@
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "DataFormats/Common/interface/ValueMap.h"
+#include "DataFormats/TrackReco/interface/Track.h"
+#include "DataFormats/TrackReco/interface/TrackFwd.h"
+#include "DataFormats/VertexReco/interface/Vertex.h"
+#include "DataFormats/VertexReco/interface/VertexFwd.h"
+
+#include <memory>
+#include <utility>
+
+#ifdef PVTX_DEBUG
+#define LOG edm::LogPrint("VertexTimeAnalyzer")
+#else
+#define LOG LogDebug("VertexTimeAnalyzer")
+#endif
+
+class VertexTimeProducer : public edm::global::EDProducer<> {
+public:
+  explicit VertexTimeProducer(edm::ParameterSet const&);
+  ~VertexTimeProducer() override = default;
+
+  static void fillDescriptions(edm::ConfigurationDescriptions&);
+
+protected:
+  void produce(edm::StreamID, edm::Event&, edm::EventSetup const&) const override;
+
+  float trackTime(float const mass, float const mtdTime, float const mtdPathLength, float const mtdMomentum) const;
+
+  bool vertexTimeFromTracks(float& vtxTime, float& vtxTimeError, reco::Vertex const& vtx, edm::ValueMap<float> const& vmapTrackMTDTimes, edm::ValueMap<float> const& vmapTrackMTDTimeErrors, edm::ValueMap<float> const& vmapTrackMTDTimeQualities, edm::ValueMap<float> const& vmapTrackMTDMomenta, edm::ValueMap<float> const& vmapTrackMTDPathLengths) const;
+
+  struct TrackInfo {
+    double trkWeight;
+    double trkTime;
+    double trkTimeError;
+    double trkTimeHyp[3];
+  };
+
+  edm::EDGetTokenT<reco::VertexCollection> const vtxsToken_;
+  bool const produceVertices_;
+
+  edm::EDGetTokenT<edm::ValueMap<float>> const trackMTDTimeToken_;
+  edm::EDGetTokenT<edm::ValueMap<float>> const trackMTDTimeErrorToken_;
+  edm::EDGetTokenT<edm::ValueMap<float>> const trackMTDTimeQualityToken_;
+  edm::EDGetTokenT<edm::ValueMap<float>> const trackMTDMomentumToken_;
+  edm::EDGetTokenT<edm::ValueMap<float>> const trackMTDPathLengthToken_;
+  float const minTrackVtxWeight_;
+  float const minTrackTimeQuality_;
+};
+
+VertexTimeProducer::VertexTimeProducer(edm::ParameterSet const& iConfig) :
+  vtxsToken_(consumes(iConfig.getParameter<edm::InputTag>("vertices"))),
+  produceVertices_(iConfig.getParameter<bool>("produceVertices")),
+
+  trackMTDTimeToken_(consumes(edm::InputTag("trackExtenderWithMTD:generalTracktmtd"))),
+  trackMTDTimeErrorToken_(consumes(edm::InputTag("trackExtenderWithMTD:generalTracksigmatmtd"))),
+  trackMTDTimeQualityToken_(consumes(edm::InputTag("mtdTrackQualityMVA:mtdQualMVA"))),
+  trackMTDMomentumToken_(consumes(edm::InputTag("trackExtenderWithMTD:generalTrackp"))),
+  trackMTDPathLengthToken_(consumes(edm::InputTag("trackExtenderWithMTD:generalTrackPathLength"))),
+  minTrackVtxWeight_(iConfig.getParameter<double>("minTrackVtxWeight")),
+  minTrackTimeQuality_(iConfig.getParameter<double>("minTrackTimeQuality")) {
+
+  produces<edm::ValueMap<float>>("time");
+  produces<edm::ValueMap<float>>("timeError");
+
+  if(produceVertices_){
+    produces<reco::VertexCollection>();
+  }
+}
+
+void VertexTimeProducer::produce(edm::StreamID, edm::Event& iEvent, edm::EventSetup const& iSetup) const {
+
+  auto const vtxsHandle = iEvent.getHandle(vtxsToken_);
+
+  // additional collections required for vertex-time calculation
+  auto const& trackMTDTimes = iEvent.get(trackMTDTimeToken_);
+  auto const& trackMTDTimeErrors = iEvent.get(trackMTDTimeErrorToken_);
+  auto const& trackMTDTimeQualities = iEvent.get(trackMTDTimeQualityToken_);
+  auto const& trackMTDMomenta = iEvent.get(trackMTDMomentumToken_);
+  auto const& trackMTDPathLengths = iEvent.get(trackMTDPathLengthToken_);
+
+  std::vector<float> vtxTimes;
+  vtxTimes.reserve(vtxsHandle->size());
+
+  std::vector<float> vtxTimeErrors;
+  vtxTimeErrors.reserve(vtxsHandle->size());
+
+  auto newVtxs = std::make_unique<reco::VertexCollection>();
+
+  if(produceVertices_){
+    newVtxs->reserve(vtxsHandle->size());
+  }
+
+  for (auto const& vtx : *vtxsHandle) {
+    auto vtxTime(0.f), vtxTimeError(-1.f);
+    vertexTimeFromTracks(vtxTime, vtxTimeError, vtx,
+      trackMTDTimes, trackMTDTimeErrors, trackMTDTimeQualities, trackMTDMomenta, trackMTDPathLengths);
+
+    LOG << "Vertex #" << vtxTimes.size() << ": x=" << vtx.x() << ", y=" << vtx.y() << ": z=" << vtx.z() << ", t=" << vtxTime << ", tError=" << vtxTimeError;
+
+    // fill values for time and timeError ValueMaps
+    vtxTimes.emplace_back(vtxTime);
+    vtxTimeErrors.emplace_back(vtxTimeError);
+
+    // fill collection of output vertices
+    if(produceVertices_){
+      // https://github.com/cms-sw/cmssw/blob/cbf578c08dd47e201eec8b64f17ae4c646e6b1a6/RecoVertex/VertexPrimitives/src/TransientVertex.cc#L301
+      if (vtx.isValid()){
+        auto err = vtx.covariance4D();
+        err(3, 3) = vtxTimeError*vtxTimeError;
+        auto vtx_new = reco::Vertex(vtx.position(), err, vtxTime, vtx.chi2(), vtx.ndof(), vtx.tracksSize());
+
+        // add tracks to vertex
+        if (vtx.hasRefittedTracks()) {
+          for(auto const& trk : vtx.refittedTracks()){
+            auto const& trk_orig = vtx.originalTrack(trk);
+            vtx_new.add(trk_orig, trk, vtx.trackWeight(trk_orig));
+          }
+        } else {
+          for(auto trk = vtx.tracks_begin(); trk != vtx.tracks_end(); ++trk){
+            vtx_new.add(*trk, vtx.trackWeight(*trk));
+          }
+        }
+
+        newVtxs->emplace_back(vtx_new);
+      }
+      else {
+        // use default reco::Vertex ctor for invalid vertex
+        newVtxs->emplace_back();
+      }
+    }
+  }
+
+  auto vtxsTimeVMap = std::make_unique<edm::ValueMap<float>>();
+  edm::ValueMap<float>::Filler vtxsTimeVMapFiller(*vtxsTimeVMap);
+  vtxsTimeVMapFiller.insert(vtxsHandle, vtxTimes.begin(), vtxTimes.end());
+  vtxsTimeVMapFiller.fill();
+  iEvent.put(std::move(vtxsTimeVMap), "time");
+
+  auto vtxsTimeErrorVMap = std::make_unique<edm::ValueMap<float>>();
+  edm::ValueMap<float>::Filler vtxsTimeErrorVMapFiller(*vtxsTimeErrorVMap);
+  vtxsTimeErrorVMapFiller.insert(vtxsHandle, vtxTimeErrors.begin(), vtxTimeErrors.end());
+  vtxsTimeErrorVMapFiller.fill();
+  iEvent.put(std::move(vtxsTimeErrorVMap), "timeError");
+
+  if(produceVertices_){
+    iEvent.put(std::move(newVtxs));
+  }
+}
+
+void VertexTimeProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<edm::InputTag>("vertices", edm::InputTag("offlinePrimaryVertices"))->setComment("input collection of vertices");
+  desc.add<bool>("produceVertices", false)->setComment("produce a collection of vertices with updated time and timeError");
+  desc.add<edm::InputTag>("tracks", edm::InputTag("generalTracks"))->setComment("input collection of tracks");
+  desc.add<double>("minTrackVtxWeight", -1.)->setComment("");
+  desc.add<double>("minTrackTimeQuality", -1.)->setComment("");
+  descriptions.addWithDefaultLabel(desc);
+}
+
+float VertexTimeProducer::trackTime(float const mass, float const mtdTime, float const mtdPathLength, float const mtdMomentum) const {
+//!!  // speed of light, c = 29.9792458 cm/ns
+//!!  return (mtdTime - mtdPathLength * std::sqrt(1.f + mass*mass/mtdMomentum/mtdMomentum) / 29.9792458f);
+  double gammasq= 1. + mtdMomentum * mtdMomentum / (mass * mass);
+  double v = 2.99792458e1 * std::sqrt(1. - 1. / gammasq);  // cm / ns
+  return mtdTime - mtdPathLength / v;
+}
+
+bool VertexTimeProducer::vertexTimeFromTracks(float& t, float& tError, reco::Vertex const& vtx, edm::ValueMap<float> const& vmapTrackMTDTimes, edm::ValueMap<float> const& vmapTrackMTDTimeErrors, edm::ValueMap<float> const& vmapTrackMTDTimeQualities, edm::ValueMap<float> const& vmapTrackMTDMomenta, edm::ValueMap<float> const& vmapTrackMTDPathLengths) const {
+  if(vtx.tracksSize() == 0){
+    return false;
+  }
+
+  auto const t_init = t;
+  auto const tError_init = tError;
+
+  double tsum = 0;
+  double wsum = 0;
+  double w2sum = 0;
+
+  double const a[3] = {0.7, 0.2, 0.1};
+  double const cooling_factor = 0.5;
+  double const minquality = 0.0;
+  double const mintrkweight = 0.5;
+
+  double const massPion = 0.139570;
+  double const massKaon = 0.493677;
+  double const massProton = 0.938272;
+
+  bool const verbose = true;
+
+  if (verbose) {
+    LOG << "vertexTimeFromTracks: vtx x=" << vtx.x() << " y=" << vtx.y() << " z=" << vtx.z() << " t=" << vtx.t();
+  }
+
+  std::vector<TrackInfo> v_trackInfo;
+  v_trackInfo.reserve(vtx.tracksSize());
+
+  // initial guess
+  for (auto trk = vtx.tracks_begin(); trk != vtx.tracks_end(); ++trk) {
+    auto const trkWeight = vtx.trackWeight(*trk);
+    if (trkWeight > mintrkweight) {
+
+      auto const trkTimeQuality = vmapTrackMTDTimeQualities[*trk];
+
+      if (trkTimeQuality >= minquality) {
+
+        auto const trkTime = vmapTrackMTDTimes[*trk];
+        auto const trkTimeError = vmapTrackMTDTimeErrors[*trk];
+        auto const trkPathLength = vmapTrackMTDPathLengths[*trk];
+        auto const trkMomentum = vmapTrackMTDMomenta[*trk];
+
+        v_trackInfo.emplace_back();
+        auto& trkInfo = v_trackInfo.back();
+
+        trkInfo.trkWeight = trkWeight;
+        trkInfo.trkTime = trkTime;
+        trkInfo.trkTimeError = trkTimeError;
+
+        if(trkPathLength > 0){
+          trkInfo.trkTimeHyp[0] = trackTime(massPion, trkTime, trkPathLength, trkMomentum);
+          trkInfo.trkTimeHyp[1] = trackTime(massKaon, trkTime, trkPathLength, trkMomentum);
+          trkInfo.trkTimeHyp[2] = trackTime(massProton, trkTime, trkPathLength, trkMomentum);
+        } else {
+          trkInfo.trkTimeHyp[0] = 0.f;
+          trkInfo.trkTimeHyp[1] = 0.f;
+          trkInfo.trkTimeHyp[2] = 0.f;
+        }
+
+        auto const wgt = trkWeight / (trkTimeError*trkTimeError);
+        wsum += wgt;
+
+        for(uint j = 0; j < 3; ++j) {
+          tsum += wgt * trkInfo.trkTimeHyp[j] * a[j];
+        }
+
+        if (verbose) {
+          LOG << "vertexTimeFromTracks:     track"
+              << " pt=" << (*trk)->pt() << " eta=" << (*trk)->eta() << " phi=" << (*trk)->phi()
+              << " vtxWeight=" << trkWeight << " time=" << trkTime << " timeError=" << trkTimeError
+              << " timeQuality=" << trkTimeQuality << " pathLength=" << trkPathLength << " momentum=" << trkMomentum
+              << " timeHyp[pion]=" << trkInfo.trkTimeHyp[0] << " timeHyp[kaon]=" << trkInfo.trkTimeHyp[1]
+              << " timeHyp[proton]=" << trkInfo.trkTimeHyp[2];
+        }
+      }
+    }
+  }
+
+  if (wsum > 0) {
+
+    if(verbose) {
+      LOG << "vertexTimeFromTracks:   wsum = " << wsum << " tsum = " << tsum << " t0 = " << (wsum > 0 ? tsum/wsum : 0) << " trec = " << vtx.t();
+    }
+
+    auto t0 = tsum / wsum;
+    auto beta = 1./256.;
+    int nit = 0;
+    while ( (nit++) < 100 ) {
+      tsum = 0;
+      wsum = 0;
+      w2sum = 0;
+
+      for (auto const& trkInfo : v_trackInfo) {
+        double dt = trkInfo.trkTimeError;
+        double e[3] = {0,0,0};
+        double Z = exp(-beta * 0.5* 3.* 3.);
+        for(unsigned int j = 0; j < 3; j++){
+          auto const tpull =  (trkInfo.trkTimeHyp[j] - t0) / dt;
+          e[j] = exp(- 0.5 * beta * tpull * tpull);
+          Z += a[j] * e[j];
+        }
+
+        double wsum_trk = 0;
+        for(uint j = 0; j < 3; j++){
+          double wt = a[j] * e[j] / Z;
+          double w = wt * trkInfo.trkWeight / (dt * dt);
+          wsum_trk += w;
+          tsum += w * trkInfo.trkTimeHyp[j]; 
+        }
+
+        wsum += wsum_trk;
+        w2sum += wsum_trk * wsum_trk * (dt * dt) / trkInfo.trkWeight;
+      }
+
+      if (wsum < 1e-10) {
+        LOG << "vertexTimeFromTracks:   failed while iterating";
+        return false;
+      }
+
+      t = tsum / wsum;
+
+      if (verbose) {
+        LOG << "vertexTimeFromTracks:   iteration=" << nit << ", T= " << 1/beta << ", t=" << t << ", t-t0=" << t-t0;
+      }
+
+      if ((std::abs(t - t0) < 1e-4 / std::sqrt(beta)) and beta >= 1.) {
+
+        tError = std::sqrt(w2sum) / wsum;
+
+        if (verbose) {
+          LOG << "vertexTimeFromTracks:   tfit = " << t << " +/- " << tError << " trec = " << vtx.t() << ", iteration=" << nit;
+        }
+
+        return true;
+      }
+
+      if ((fabs(t - t0) < 1e-3) and beta < 1.) {
+        beta = std::min(1., beta / cooling_factor);
+      }
+
+      t0 = t;
+    }
+
+    LOG << "vertexTimeFromTracks: failed to converge";
+  }
+  else {
+    LOG << "vertexTimeFromTracks: has no track timing info";
+  }
+
+  t = t_init;
+  tError = tError_init;
+
+  return false;
+}
+
+DEFINE_FWK_MODULE(VertexTimeProducer);

--- a/PrimaryVertexAnalyzer/src/PrimaryVertexAnalyzer4PU.cc
+++ b/PrimaryVertexAnalyzer/src/PrimaryVertexAnalyzer4PU.cc
@@ -2039,10 +2039,12 @@ PrimaryVertexAnalyzer4PU::~PrimaryVertexAnalyzer4PU() {
 
     addnSP(h, new TH2F("tkptrecsimrelvssimeta2d", "(pTrec-pTsim)/pTrec vs eta_{TP}", netabin, -etarange, etarange, 300, -0.3, 0.3));
     addnSP(h, new TH2F("tkptrecsimpullvssimeta2d", "pTrec-pTsim pull vs eta_{TP}", netabin, -etarange, etarange, 100, -15., 15.));
+    addnSP(h, new TH2F("tkdptrelrecvssimeta2d", "#sigma(pTrec)/pTrec vs eta_{TP}", netabin, -etarange, etarange, 100, -3., 3.));
     addnSP(h, new TH2F("tketarecsimvssimeta2d", "etarec-etasim vs eta_{TP}", netabin, -etarange, etarange, 100, -0.05, 0.05));
     addnSP(h, new TH2F("tkphirecsimvssimeta2d", "phirec-phisim vs eta_{TP}", netabin, -etarange, etarange, 100, -0.05, 0.05));
     addnSP(h, new TH2F("tkzrecsimvssimeta2d", "zrec-zsim vs eta_{TP}", netabin, -etarange, etarange, 200, -0.2, 0.2));
     addnSP(h, new TH2F("tkzrecsimpullvssimeta2d" , "zrec-zsim pull vs eta_{TP}", netabin, -etarange, etarange, 300, -15., 15.));
+    addnSP(h, new TH2F("tkdzrecvssimeta2d", "zError vs eta_{TP}", netabin, -etarange, etarange, 200, -0.2, 0.2));
 
     addnSP(h, new TH1D("tktrecsim", "trec-tsim", 200, -0.3, 0.3));
     addnSP(h, new TH1D("tktrecsimpull", "(trec-tsim)/terr", 200, -10., 10.));
@@ -4244,6 +4246,14 @@ bool PrimaryVertexAnalyzer4PU::vertex_time_from_tracks_pid(const reco::Vertex& v
   double wsum = 0;
   double w2sum = 0;
 
+  if(verbose) {
+    cout << "vertex_time_from_tracks_pid vtx x=" << v.x()
+	 << " y=" << v.y()
+	 << " z=" << v.z()
+	 << " t=" << v.t()
+         << endl;
+  }
+
   //double a[3] = {0.333333333,0.33333333,0.333333333};
   double a[3] = {0.7,0.2,0.1};
   constexpr double cooling_factor = 0.5;
@@ -4257,11 +4267,19 @@ bool PrimaryVertexAnalyzer4PU::vertex_time_from_tracks_pid(const reco::Vertex& v
 	for(unsigned int j=0; j < 3; j++){
 	  tsum += w * trk.th[j] * a[j];
 	}
+
+	if(verbose){
+          cout << "vertex_time_from_tracks_pid:     track"
+               << " pt=" << trk.pt() << " eta=" << trk.eta() << " phi=" << trk.phi() << " t=" << trk.t()
+               << " vtxWeight=" << v.trackWeight(*tk) << " time=" << trk.MTD_time() << " timeError=" << trk.MTD_timeerror()
+               << " timeQuality=" << trk.timeQuality() << " pathLength=" << trk.MTD_pathlength() << " momentum=" << trk.MTD_momentum()
+               << " timeHyp[pion]=" << trk.th[0] << " timeHyp[kaon]=" << trk.th[1]
+               << " timeHyp[proton]=" << trk.th[2] << endl;
+        }
       }
     }
   }
 
-  
   if (wsum > 0) {
 
     if(verbose) {
@@ -4334,17 +4352,17 @@ bool PrimaryVertexAnalyzer4PU::vertex_time_from_tracks_pid(const reco::Vertex& v
 		      e[j] = exp(- 0.5 * beta * tpull * tpull);
 		      Z += a[j] * e[j];
 		    }
-		    cout << "    " << fixed << setw(7) << setprecision(3) << trk.t() 
-			 << "+/-" << fixed << setw(6) << setprecision(3) << dt;
+		    cout << "    " << fixed << setw(7) << setprecision(7) << trk.t() 
+			 << "+/-" << fixed << setw(6) << setprecision(7) << dt;
 		    for(unsigned int j = 0; j < 3; j++){
 		      double wt = a[j] * e[j] / Z;
 		      cout << "  [" <<  fixed << setw(1) << j << "]  " 
-			   << fixed << setw(7) << setprecision(3) << trk.th[j] << "ns  " 
+			   << fixed << setw(7) << setprecision(7) << trk.th[j] << "ns  " 
 			   << fixed << setw(7) << setprecision(5) << wt;  
 		    }
 		    if(trk.matched()) {
-		      cout << "   m " << fixed << setw(8) << setprecision(3) << trk.get_t_pid()
-			   << " gen " << fixed << setw(8) << setprecision(3) << trk.tsim();
+		      cout << "   m " << fixed << setw(8) << setprecision(7) << trk.get_t_pid()
+			   << " gen " << fixed << setw(8) << setprecision(7) << trk.tsim();
 		    }
 		    cout << endl;
 		  }
@@ -4535,17 +4553,17 @@ bool PrimaryVertexAnalyzer4PU::vertex_time_from_tracks_pid_newton(const reco::Ve
 		      e[j] = exp(- 0.5 * beta * tpull * tpull);
 		      Z += a[j] * e[j];
 		    }
-		    cout << "    " << fixed << setw(7) << setprecision(3) << trk.t() 
-			 << "+/-" << fixed << setw(6) << setprecision(3) << dt;
+		    cout << "    " << fixed << setw(7) << setprecision(7) << trk.t() 
+			 << "+/-" << fixed << setw(6) << setprecision(7) << dt;
 		    for(unsigned int j = 0; j < 3; j++){
 		      double wt = a[j] * e[j] / Z;
 		      cout << "  [" <<  fixed << setw(1) << j << "]  " 
-			   << fixed << setw(7) << setprecision(3) << trk.th[j] << "ns  " 
+			   << fixed << setw(7) << setprecision(7) << trk.th[j] << "ns  " 
 			   << fixed << setw(7) << setprecision(5) << wt;  
 		    }
 		    if(trk.matched()) {
-		      cout << "   m " << fixed << setw(8) << setprecision(3) << trk.get_t_pid()
-			   << " gen " << fixed << setw(8) << setprecision(3) << trk.tsim();
+		      cout << "   m " << fixed << setw(8) << setprecision(7) << trk.get_t_pid()
+			   << " gen " << fixed << setw(8) << setprecision(7) << trk.tsim();
 		    }
 		    cout << endl;
 		  }
@@ -5318,6 +5336,8 @@ void PrimaryVertexAnalyzer4PU::fillTrackHistosMatched(std::map<std::string, TH1*
   auto const isSignalPV = (tk._simEvt->index == 0);
 
   auto const rec_pt = tk.pt();
+  auto const rec_dpt = tk.ptError();
+  auto const rec_dptrel = rec_dpt/rec_pt;
   auto const rec_eta = tk.eta();
   auto const rec_phi = tk.phi();
   auto const rec_z = tk.z();
@@ -5330,7 +5350,7 @@ void PrimaryVertexAnalyzer4PU::fillTrackHistosMatched(std::map<std::string, TH1*
 
   auto const dptDiff = (rec_pt - sim_pt);
   auto const dptDiffRel = dptDiff/rec_pt;
-  auto const dptPull = dptDiff/tk.ptError();
+  auto const dptPull = dptDiff/rec_dpt;
   auto const detaDiff = (rec_eta - sim_eta);
   auto const dphiDiff = reco::deltaPhi(rec_phi, sim_phi);
 
@@ -5349,10 +5369,12 @@ void PrimaryVertexAnalyzer4PU::fillTrackHistosMatched(std::map<std::string, TH1*
 
   Fill(h, ttype + "/tkptrecsimrelvssimeta2d", sim_eta, dptDiffRel, isSignalPV);
   Fill(h, ttype + "/tkptrecsimpullvssimeta2d", sim_eta, dptPull, isSignalPV);
+  Fill(h, ttype + "/tkdptrelrecvssimeta2d", sim_eta, rec_dptrel, isSignalPV);
   Fill(h, ttype + "/tketarecsimvssimeta2d", sim_eta, detaDiff, isSignalPV);
   Fill(h, ttype + "/tkphirecsimvssimeta2d", sim_eta, dphiDiff, isSignalPV);
   Fill(h, ttype + "/tkzrecsimvssimeta2d", sim_eta, dzDiff, isSignalPV);
   Fill(h, ttype + "/tkzrecsimpullvssimeta2d", sim_eta, dzPull, isSignalPV);
+  Fill(h, ttype + "/tkdzrecvssimeta2d", sim_eta, rec_dz, isSignalPV);
 
   if (f4D_ and tk.has_timing()){
 

--- a/PrimaryVertexAnalyzer/test/vertexTimeAnalyzer_cfg.py
+++ b/PrimaryVertexAnalyzer/test/vertexTimeAnalyzer_cfg.py
@@ -1,0 +1,323 @@
+import FWCore.ParameterSet.Config as cms
+
+# command-line arguments
+import FWCore.ParameterSet.VarParsing as VarParsing
+opts = VarParsing.VarParsing('analysis')
+
+opts.register('skipEvents', 0,
+              VarParsing.VarParsing.multiplicity.singleton,
+              VarParsing.VarParsing.varType.int,
+              'number of events to be skipped')
+
+opts.register('dumpPython', None,
+              VarParsing.VarParsing.multiplicity.singleton,
+              VarParsing.VarParsing.varType.string,
+              'path to python file with content of cms.Process')
+
+opts.register('numThreads', 1,
+              VarParsing.VarParsing.multiplicity.singleton,
+              VarParsing.VarParsing.varType.int,
+              'number of threads')
+
+opts.register('numStreams', 0,
+              VarParsing.VarParsing.multiplicity.singleton,
+              VarParsing.VarParsing.varType.int,
+              'number of streams')
+
+opts.register('reco', 'Phase2_D77',
+              VarParsing.VarParsing.multiplicity.singleton,
+              VarParsing.VarParsing.varType.string,
+              'keyword to select base configuration file')
+
+opts.register('globalTag', None,
+              VarParsing.VarParsing.multiplicity.singleton,
+              VarParsing.VarParsing.varType.string,
+              'argument of process.GlobalTag')
+
+opts.register('wantSummary', False,
+              VarParsing.VarParsing.multiplicity.singleton,
+              VarParsing.VarParsing.varType.bool,
+              'show cmsRun summary at job completion')
+
+opts.register('verbosity', 0,
+              VarParsing.VarParsing.multiplicity.singleton,
+              VarParsing.VarParsing.varType.int,
+              'level of output verbosity')
+
+# custom defaults
+opts.setDefault('maxEvents', 10)
+opts.setType('outputFile', VarParsing.VarParsing.varType.string)
+opts.setDefault('outputFile', 'tmp.root')
+
+opts.parseArguments()
+
+###
+### base configuration file
+###
+cmsDriverArgsDict = {
+
+  'Phase2_D77': """
+ --conditions auto:phase2_realistic_T21
+ --era Phase2C11I13M9
+ --geometry Extended2026D77
+ --filein /store/relval/CMSSW_12_3_0_pre4/RelValTTbar_14TeV/GEN-SIM-RECO/PU_123X_mcRun4_realistic_v3_2026D77PU200-v2/10000/b9af4417-47fc-4a82-bc60-de376040fb83.root
+ --customise SLHCUpgradeSimulations/Configuration/aging.customise_aging_1000
+ --step RECO
+""",
+}
+
+if opts.reco in cmsDriverArgsDict:
+  cmsDriverCmd = cmsDriverArgsDict[opts.reco]
+  # remove newlines and spurious whitespaces
+  cmsDriverCmd = ' '.join(cmsDriverCmd.replace('\n','').split())
+
+  if len(opts.inputFiles) > 0:
+    cmsDriverCmd += ' --filein '+','.join(opts.inputFiles)
+else:
+  raise RuntimeError('invalid argument for option "reco": "'+opts.reco+'" (allowed values: '+str(sorted(cmsDriverArgsDict.keys()))+')')
+
+# create, load and remove the configuration file
+import glob
+import os
+
+cfg_filepath = os.environ['PWD']+'/tmp_cfg.py'
+
+# Process
+def EXE(cmd, suspend=True, verbose=False, dry_run=False):
+    if verbose: print('\033[1m'+'>'+'\033[0m'+' '+cmd)
+    if dry_run: return
+    _exitcode = os.system(cmd)
+    _exitcode = min(255, _exitcode)
+    if _exitcode and suspend:
+       raise RuntimeError(_exitcode)
+    return _exitcode
+
+EXE('cmsDriver.py '+cmsDriverCmd+' --processName ANALYSIS --number 100 --no_exec --python_filename '+cfg_filepath)
+from tmp_cfg import cms, process
+for _tmpf in glob.glob(cfg_filepath+'*'):
+  os.remove(_tmpf)
+
+# remove OutputModules of base configuration
+for _modname in process.outputModules_():
+  _mod = getattr(process, _modname)
+  if type(_mod) == cms.OutputModule:
+    process.__delattr__(_modname)
+    if opts.verbosity > 0:
+      print('> removed cms.OutputModule:', _modname)
+
+# Input source
+if opts.inputFiles != []:
+  process.source.fileNames = opts.inputFiles
+  process.source.secondaryFileNames = opts.secondaryInputFiles
+process.source.skipEvents = cms.untracked.uint32(opts.skipEvents)
+
+# Output file (TFileService)
+process.TFileService = cms.Service('TFileService',
+    fileName = cms.string(opts.outputFile)
+)
+
+# Job configuration parameters (special PSets)
+process.maxEvents.input = opts.maxEvents
+
+process.options.numberOfConcurrentLuminosityBlocks = 0
+process.options.numberOfConcurrentRuns = 1
+process.options.numberOfStreams = max(opts.numStreams, 0)
+process.options.numberOfThreads = max(opts.numThreads, 1)
+process.options.wantSummary = opts.wantSummary
+
+# GlobalTag
+if opts.globalTag is not None:
+    from Configuration.AlCa.GlobalTag import GlobalTag
+    process.GlobalTag = GlobalTag(process.GlobalTag, opts.globalTag, '')
+
+###
+### Schedule
+###
+process.setSchedule_(cms.Schedule())
+
+from usercode.PrimaryVertexAnalyzer.vertexTimeProducer_cfi import vertexTimeProducer as _vertexTimeProducer
+process.offlinePrimaryVerticesTimeMethod1 = _vertexTimeProducer.clone(
+    vertices = 'offlinePrimaryVertices',
+    tracks = 'generalTracks',
+    produceVertices = True,
+)
+
+def histoPSet(_valueMapTag, _nbins, _xmin, _xmax):
+  return cms.PSet(valueMapTag = cms.InputTag(_valueMapTag), nbins = cms.uint32(_nbins), xmin = cms.double(_xmin), xmax = cms.double(_xmax))
+
+from usercode.PrimaryVertexAnalyzer.vertexTimeAnalyzer_cfi import vertexTimeAnalyzer as _vertexTimeAnalyzer
+process.VertexHistograms_offlinePrimaryVertices = _vertexTimeAnalyzer.clone(
+    vertices = 'offlinePrimaryVertices',
+    maxNumberOfVertices = -1,
+    histogramNamePrefix = 'vertex_',
+    histogramPSet = cms.PSet(
+      t_method1 = histoPSet('offlinePrimaryVerticesTimeMethod1:time', 600, -30, 30),
+      tError_method1 = histoPSet('offlinePrimaryVerticesTimeMethod1:timeError', 300, 0, 30)
+    )
+)
+
+process.vertexAnalysisPath = cms.Path(
+    process.offlinePrimaryVerticesTimeMethod1
+  + process.VertexHistograms_offlinePrimaryVertices
+)
+
+process.schedule_().append(process.vertexAnalysisPath)
+
+## PrimaryVertexAnalyzer4PU
+parameters = { # can be overwritten by arguments of the same name
+  '4D': cms.untracked.bool(True),
+  'selNdof': cms.untracked.double(4.0),
+  'selNdofWithBS': cms.untracked.double(7.0),
+#  'splitmethod': cms.untracked.int32(0),
+  'usefit': cms.untracked.bool(False),
+  'use_tp': cms.untracked.bool(True),
+  'use2file': cms.untracked.bool(False),
+#  'ptrunc': cms.untracked.double(1.e-50),
+  'fill_track_histos': cms.untracked.bool(True),
+  'fplo': cms.untracked.double(0),
+  'chi2cutoff': cms.double(2.5),
+  'verboseAnalyzer': cms.untracked.bool(False),
+  'verboseProducer': cms.untracked.bool(False),
+  'verboseClusterizer': cms.untracked.bool(False),
+  'verboseClusterizer2D': cms.untracked.bool(False),
+  'zdumpcenter': cms.untracked.double(0.0),
+  'zdumpwidth': cms.untracked.double(20.0),
+  'reco': cms.untracked.bool(False),
+  'miniaod': cms.untracked.bool(False),
+  'autodump': cms.untracked.int32(0),
+  'nDump': cms.untracked.int32(0),
+  'nDumpTracks': cms.untracked.int32(0),
+#  'mintrkweight': cms.untracked.double(0.5),
+  'uniquetrkweight': cms.double(0.8),
+  'uniquetrkminp': cms.double(0.0),
+  'zmerge': cms.double(1.e-2),
+  'coolingFactor': cms.double(0.6),
+  'Tmin': cms.double(2.0),
+  'Tpurge': cms.double(2.0),
+  'Tstop': cms.double(0.5),
+  'vertexSize': cms.double(0.006),
+  'vertexSizeTime': cms.double(0.008),
+  'd0CutOff': cms.double(3.),
+  'dzCutOff': cms.double(3.),
+  'zrange': cms.double(4),
+  'convergence_mode': cms.int32(0),
+  'delta_lowT': cms.double(1.e-3),
+  'delta_highT': cms.double(1.e-2),
+  # track selection
+  'maxNormalizedChi2': cms.double(10.0),
+  'minPixelLayersWithHits': cms.int32(2),
+  'minSiliconLayersWithHits': cms.int32(5),
+  'maxD0Significance': cms.double(4.0),
+  'minPt': cms.double(0.0),
+  'maxEta': cms.double(4.0),
+  'trackQuality': cms.string('any'),
+  # track selection, experimental
+  'maxDzError': cms.double(1.0),
+  'maxD0Error': cms.double(1.0),
+  # vertex selection
+  'minNdof': cms.double(0.0),
+  # temp
+  'trackTimeQualityThreshold': cms.untracked.double(0.8),
+  'purge': cms.untracked.int32(0),
+  'rho0mode': cms.untracked.int32(0),  # /nt, as before
+  'mergenotc': cms.untracked.bool(False),
+  'mergeafterpurge': cms.untracked.bool(False),
+  'fillzmerge': cms.untracked.double(0.0060), # default = vertexSize
+  'use_hitpattern': cms.untracked.int32(0),
+  'use_pt': cms.untracked.int32(0)
+}
+
+from RecoVertex.Configuration.RecoVertex_cff import unsortedOfflinePrimaryVertices as _unsortedOfflinePrimaryVertices
+tkFilterParameters = _unsortedOfflinePrimaryVertices.TkFilterParameters.clone()
+print('original trackFilterParameters (z-clustering)')
+print(tkFilterParameters)
+for par_name in [
+  'maxNormalizedChi2',
+  'minPixelLayersWithHits',
+  'minSiliconLayersWithHits',
+  'maxD0Significance',
+  'maxD0Error',
+  'maxDzError',
+  'minPt',
+  'maxEta',
+  'trackQuality',
+]:
+  try:
+    default = getattr(tkFilterParameters, par_name)
+    if default != parameters[par_name]:
+      print('changing tkFilter parameter', par_name, 'from', default, 'to', parameters[par_name])
+    setattr(tkFilterParameters, par_name, parameters[par_name])
+  except ValueError:
+    print('pva_cfg: attribute tkFilterParameters.'+par_name, 'not found')
+
+## PV analyser
+process.vertexAnalyser = cms.EDAnalyzer('PrimaryVertexAnalyzer4PU',
+  info = cms.untracked.string('test'),
+  f4D = parameters['4D'],
+  selNdof = parameters['selNdof'],
+  selNdofWithBS = parameters['selNdofWithBS'],
+  beamSpot = cms.InputTag('offlineBeamSpot'),
+  simG4 = cms.InputTag('g4SimHits'),
+  outputFile = cms.untracked.string(opts.outputFile[:-5]+'_pvtx.root'),
+  verbose = parameters['verboseAnalyzer'],
+  veryverbose = cms.untracked.bool(False),
+  recoTrackProducer = cms.untracked.string('generalTracks'),
+  zmatch = cms.untracked.double(0.05),
+  autodump = parameters['autodump'],
+  nDump = parameters['nDump'],
+  nDumpTracks = parameters['nDumpTracks'],
+  RECO = parameters['reco'],
+  MINIAOD = parameters['miniaod'],
+  use_tp = parameters['use_tp'],
+  fill_track_histos = parameters['fill_track_histos'],
+  track_timing = cms.untracked.bool(True),
+  TkFilterParameters = tkFilterParameters,
+  trackingParticleCollection = cms.untracked.InputTag('mix', 'MergedTrackTruth'),
+  trackingVertexCollection = cms.untracked.InputTag('mix', 'MergedTrackTruth'),
+  trackAssociatorMap = cms.untracked.InputTag('trackingParticleRecoTrackAsssociation'),
+  TrackTimesLabel = cms.untracked.InputTag('tofPID:t0safe'),
+  TrackTimeResosLabel = cms.untracked.InputTag('tofPID:sigmat0safe'),
+#  TrackTimesLabel = cms.untracked.InputTag('tofPID:t0safe'),
+#  TrackTimeResosLabel = cms.untracked.InputTag('tofPID:sigmat0safe'),
+  TrackTimeQualityMapLabel = cms.untracked.InputTag('mtdTrackQualityMVA:mtdQualMVA'),
+  TrackTimeQualityThreshold = cms.untracked.double(parameters['trackTimeQualityThreshold'].value()),
+  vertexAssociator = cms.untracked.InputTag('VertexAssociatorByPositionAndTracks'),
+  lumiInfoTag = cms.untracked.InputTag('LumiInfo', 'brilcalc'),
+  useVertexFilter = cms.untracked.bool(False),
+  compareCollections = cms.untracked.int32(0),
+  vertexRecoCollections = cms.VInputTag(
+    'offlinePrimaryVerticesTimeMethod1',
+  ),
+)
+
+process.vertexAnalysisEndPath = cms.EndPath(process.vertexAnalyser)
+process.schedule_().append(process.vertexAnalysisEndPath)
+
+## recoTrack<->TrackingParticle associator
+if parameters['use_tp']:
+  process.load('Validation.RecoTrack.TrackValidation_cff')
+  process.trackingParticleAssociationTask = cms.Task(
+    process.tpClusterProducer,
+    process.quickTrackAssociatorByHits,
+    process.trackingParticleRecoTrackAsssociation
+  )
+  process.trackingParticleAssociationPath = cms.Path(process.trackingParticleAssociationTask)
+  process.schedule_().append(process.trackingParticleAssociationPath)
+
+# prune and dump content of cms.Process to python file
+if opts.dumpPython is not None:
+    process.prune()
+    open(opts.dumpPython, 'w').write(process.dumpPython())
+
+# printouts
+if opts.verbosity > 0:
+    print('--- vertexTimeAnalyser_cfg.py ---')
+    print('')
+    print('option: outputFile =', opts.outputFile)
+    print('option: dumpPython =', opts.dumpPython)
+    print('')
+    print('process.GlobalTag =', process.GlobalTag.dumpPython())
+    print('process.source =', process.source.dumpPython())
+    print('process.maxEvents =', process.maxEvents.dumpPython())
+    print('process.options =', process.options.dumpPython())
+    print('-------------------------------')


### PR DESCRIPTION
#### Description:

This PR adds a standalone workflow to write and read a vertex time (and timeError) value calculated as in the function `PrimaryVertexAnalyzer4PU::vertex_time_from_tracks_pid`.

The workflow is made of mainly 3 parts.

 - `VertexTimeProducer`: a producer that, given an input collection of vertices, creates two ValueMaps ("time" and "timeError") holding the result of the vertex-time/timeError calculation; the same producer can optionally create a new collection of vertices with updated time and timeError values (flag: `produceVertices`).

 - `VertexTimeAnalyzer`: a simple analyzer that produces histograms in a ROOT file (created via TFileService); this can be configured to add the time/timeError values of different ValueMaps (for example, different ValueMaps coming from different instances of `VertexTimeProducer`).

 - `vertexTimeAnalyzer_cfg.py`: a configuration file to test the new plugins, and compare their outputs with those of the standard analyzer, i.e. `PrimaryVertexAnalyzer4PU`; the configuration runs the `VertexTimeProducer`, the `VertexTimeAnalyzer` to plot some basic quantities, and the `PrimaryVertexAnalyzer4PU` on the new vertices produced by the `VertexTimeProducer` module (these new vertices already have the new vertex-time estimate stored internally, i.e. `reco::Vertex::time()`).

The PR also modifies some printouts in `PrimaryVertexAnalyzer4PU`, to make them similar to the ones in `VertexTimeProducer` (for easier comparisons). There is also an addition of two histograms in `PrimaryVertexAnalyzer4PU` which are not related to this PR (I figured this did not deserve its own PR).

#### Recipe to test:

```sh
cmsrel CMSSW_12_3_0_pre4
cd CMSSW_12_3_0_pre4/src
cmsenv
git cms-init
git clone https://github.com/missirol/PVAnalysis.git usercode -o missirol -b devel_vtxTime
scram b
voms-proxy-init --voms cms --rfc --valid 168:00
cmsRun usercode/PrimaryVertexAnalyzer/test/vertexTimeAnalyzer_cfg.py &> out.log
```

#### Validation:

Starting from the recipe above, I manually modified `PrimaryVertexAnalyzer4PU` to (1) use all the available tracks without the `has_timing` requirement which is used inside `PrimaryVertexAnalyzer4PU`, and (2) fill the relevant histograms even when the iterative procedure fails (because the vertex-time-producer currently assigns a value of t=0 even if the iterative procedure fails):
```diff
diff --git a/PrimaryVertexAnalyzer/interface/PrimaryVertexAnalyzer4PU.h b/PrimaryVertexAnalyzer/interface/PrimaryVertexAnalyzer4PU.h
index 2718838..b2d138e 100644
--- a/PrimaryVertexAnalyzer/interface/PrimaryVertexAnalyzer4PU.h
+++ b/PrimaryVertexAnalyzer/interface/PrimaryVertexAnalyzer4PU.h
@@ -851,10 +851,10 @@ public:
       if (f4D) {
         _t = _transientTrack.timeExt();
         _dt = _transientTrack.dtErrorExt();
-        if ((_dt > 0) && (_dt < 0.5)){// ?? && (!((_t==0) && (std::abs(_dt) <-0.35)<1e-5)))) {
+//        if ((_dt > 0) && (_dt < 0.5)){// ?? && (!((_t==0) && (std::abs(_dt) <-0.35)<1e-5)))) {
           _has_timing = true;
          _timeQuality = 1.; // temporary, overridden externally for now in get_reco_and_transient_tracks
-        }
+//        }
       }
     }
 
diff --git a/PrimaryVertexAnalyzer/src/PrimaryVertexAnalyzer4PU.cc b/PrimaryVertexAnalyzer/src/PrimaryVertexAnalyzer4PU.cc
index 844e9eb..7fd38b4 100644
--- a/PrimaryVertexAnalyzer/src/PrimaryVertexAnalyzer4PU.cc
+++ b/PrimaryVertexAnalyzer/src/PrimaryVertexAnalyzer4PU.cc
@@ -5116,7 +5116,7 @@ void PrimaryVertexAnalyzer4PU::fillVertexHistosMatched(std::map<std::string, TH1
          //reportVertex(*v, Form("timing from tracks failed,  with tracks: %f", v.tError()), false);
        }
 
-      if (timing_from_tracks_pid)
+      if (timing_from_tracks_pid or true)
        {
          // timing from tracks
          Fill(h, vtype + "/trecsim_fromtracks_pid" , t_fromtracks_pid- simevt.t, simevt.is_signal());
```
With this, I (recompiled and) re-ran `cmsRun vertexTimeAnalyzer_cfg.py`. In the output file `tmp_pvtx.root` (produced by the main analyzer, i.e. `PrimaryVertexAnalyzer4PU`), the histograms `offlinePrimaryVerticesTimeMethod1/matchedvtx/trecsim` (vertex time of newly created vertices) and `offlinePrimaryVerticesTimeMethod1/matchedvtx/trecsim_fromtracks_pid` (vertex time calculated using the original implementation inside the analyzer) show the same exact content. This confirms that the time computation in the standalone producer and in the reference analyzer return the same values (when using the same tracks), at least for all the sim-matched vertices of the ten PU200 events used for this validation.

#### Comments

Two weak points of the current implementation are the following:

 - `VertexTimeProducer`: the producer supports only the method corresponding to `PrimaryVertexAnalyzer4PU::vertex_time_from_tracks_pid`, and the latter algorithm is embedded in the producer. It should be possible to decouple producer and algorithm, in order to eventually have 1 producer and N algorithms (each algorithm would be a separate "plugin helper" class, choosable/configurable from the python configuration of the producer). Overall, `VertexTimeProducer` still requires some polishing (e.g. removal of "magic numbers") to conform to CMSSW coding rules.

 - `VertexTimeAnalyzer`: this currently has no knowledge of `TrackingVertices`, or reco-sim matching (this means that the produced histograms do not include "t_reco - t_sim").