### PR TITLE
introduce `VertexTimeAlgorithmBaseFactory` in `VertexTimeProducer`

### DIFF
--- a/PrimaryVertexAnalyzer/plugins/BuildFile.xml
+++ b/PrimaryVertexAnalyzer/plugins/BuildFile.xml
@@ -3,7 +3,10 @@
   <use name="FWCore/Framework"/>
   <use name="FWCore/ParameterSet"/>
   <use name="FWCore/MessageLogger"/>
+  <use name="FWCore/PluginManager"/>
+  <use name="FWCore/Utilities"/>
   <use name="CommonTools/Utils"/>
   <use name="CommonTools/UtilAlgos"/>
+  <use name="DataFormats/Common"/>
   <use name="DataFormats/VertexReco"/>
 </library>

--- a/PrimaryVertexAnalyzer/plugins/VertexTimeAlgorithmBase.h
+++ b/PrimaryVertexAnalyzer/plugins/VertexTimeAlgorithmBase.h
@@ -1,0 +1,29 @@
+#ifndef usercode_PrimaryVertexAnalyzer_VertexTimeAlgorithmBase_h
+#define usercode_PrimaryVertexAnalyzer_VertexTimeAlgorithmBase_h
+
+namespace edm {
+  class Event;
+  class EventSetup;
+  class ParameterSet;
+  class ParameterSetDescription;
+  class ConsumesCollector;
+}
+
+namespace reco {
+  class Vertex;
+}
+
+class VertexTimeAlgorithmBase {
+ public:
+  VertexTimeAlgorithmBase(const edm::ParameterSet& conf, edm::ConsumesCollector& iC) {}
+  virtual ~VertexTimeAlgorithmBase() = default;
+  VertexTimeAlgorithmBase(const VertexTimeAlgorithmBase&) = delete;
+  VertexTimeAlgorithmBase& operator=(const VertexTimeAlgorithmBase&) = delete;
+
+  static void fillPSetDescription(edm::ParameterSetDescription& iDesc) {}
+
+  virtual void setEvent(edm::Event& iEvent, edm::EventSetup const& iSetup) = 0;
+  virtual bool vertexTime(float& vtxTime, float& vtxTimeError, reco::Vertex const& vtx) const = 0;
+};
+
+#endif

--- a/PrimaryVertexAnalyzer/plugins/VertexTimeAlgorithmBaseFactory.cc
+++ b/PrimaryVertexAnalyzer/plugins/VertexTimeAlgorithmBaseFactory.cc
@@ -1,0 +1,4 @@
+#include "FWCore/ParameterSet/interface/ValidatedPluginFactoryMacros.h"
+#include "VertexTimeAlgorithmBaseFactory.h"
+
+EDM_REGISTER_VALIDATED_PLUGINFACTORY(VertexTimeAlgorithmBaseFactory, "VertexTimeAlgorithmBaseFactory");

--- a/PrimaryVertexAnalyzer/plugins/VertexTimeAlgorithmBaseFactory.h
+++ b/PrimaryVertexAnalyzer/plugins/VertexTimeAlgorithmBaseFactory.h
@@ -1,0 +1,14 @@
+#ifndef usercode_PrimaryVertexAnalyzer_VertexTimeAlgorithmBaseFactory_h
+#define usercode_PrimaryVertexAnalyzer_VertexTimeAlgorithmBaseFactory_h
+
+#include "FWCore/PluginManager/interface/PluginFactory.h"
+#include "VertexTimeAlgorithmBase.h"
+
+namespace edm {
+  class ParameterSet;
+  class ConsumesCollector;
+}
+
+typedef edmplugin::PluginFactory<VertexTimeAlgorithmBase*(const edm::ParameterSet&, edm::ConsumesCollector& iC)> VertexTimeAlgorithmBaseFactory;
+
+#endif

--- a/PrimaryVertexAnalyzer/plugins/VertexTimeAlgorithmFromTracksPID.cc
+++ b/PrimaryVertexAnalyzer/plugins/VertexTimeAlgorithmFromTracksPID.cc
@@ -1,0 +1,209 @@
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ValidatedPluginMacros.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "DataFormats/VertexReco/interface/Vertex.h"
+
+#include "VertexTimeAlgorithmFromTracksPID.h"
+#include "VertexTimeAlgorithmBaseFactory.h"
+
+#ifdef PVTX_DEBUG
+#define LOG edm::LogPrint("VertexTimeAlgorithmFromTracksPID")
+#else
+#define LOG LogDebug("VertexTimeAlgorithmFromTracksPID")
+#endif
+
+VertexTimeAlgorithmFromTracksPID::VertexTimeAlgorithmFromTracksPID(edm::ParameterSet const& iConfig, edm::ConsumesCollector& iCC) :
+  VertexTimeAlgorithmBase(iConfig, iCC),
+  trackMTDTimeToken_(iCC.consumes(iConfig.getParameter<edm::InputTag>("trackMTDTimeVMapTag"))),
+  trackMTDTimeErrorToken_(iCC.consumes(iConfig.getParameter<edm::InputTag>("trackMTDTimeErrorVMapTag"))),
+  trackMTDTimeQualityToken_(iCC.consumes(iConfig.getParameter<edm::InputTag>("trackMTDTimeQualityVMapTag"))),
+  trackMTDMomentumToken_(iCC.consumes(iConfig.getParameter<edm::InputTag>("trackMTDMomentumVMapTag"))),
+  trackMTDPathLengthToken_(iCC.consumes(iConfig.getParameter<edm::InputTag>("trackMTDPathLengthVMapTag"))),
+  minTrackVtxWeight_(iConfig.getParameter<double>("minTrackVtxWeight")),
+  minTrackTimeQuality_(iConfig.getParameter<double>("minTrackTimeQuality")),
+  massPion_(iConfig.getParameter<double>("massPion")),
+  massKaon_(iConfig.getParameter<double>("massKaon")),
+  massProton_(iConfig.getParameter<double>("massProton")),
+  probPion_(iConfig.getParameter<double>("probPion")),
+  probKaon_(iConfig.getParameter<double>("probKaon")),
+  probProton_(iConfig.getParameter<double>("probProton")),
+  coolingFactor_(iConfig.getParameter<double>("coolingFactor")) {}
+
+void VertexTimeAlgorithmFromTracksPID::fillPSetDescription(edm::ParameterSetDescription& iDesc) {
+  VertexTimeAlgorithmBase::fillPSetDescription(iDesc);
+
+  iDesc.add<edm::InputTag>("trackMTDTimeVMapTag", edm::InputTag("trackExtenderWithMTD:generalTracktmtd"))->setComment("");
+  iDesc.add<edm::InputTag>("trackMTDTimeErrorVMapTag", edm::InputTag("trackExtenderWithMTD:generalTracksigmatmtd"))->setComment("");
+  iDesc.add<edm::InputTag>("trackMTDTimeQualityVMapTag", edm::InputTag("mtdTrackQualityMVA:mtdQualMVA"))->setComment("");
+  iDesc.add<edm::InputTag>("trackMTDMomentumVMapTag", edm::InputTag("trackExtenderWithMTD:generalTrackp"))->setComment("");
+  iDesc.add<edm::InputTag>("trackMTDPathLengthVMapTag", edm::InputTag("trackExtenderWithMTD:generalTrackPathLength"))->setComment("");
+
+  iDesc.add<double>("minTrackVtxWeight", 0.5)->setComment("");
+  iDesc.add<double>("minTrackTimeQuality", 0.)->setComment("");
+
+  iDesc.add<double>("massPion", 0.139570)->setComment("");
+  iDesc.add<double>("massKaon", 0.493677)->setComment("");
+  iDesc.add<double>("massProton", 0.938272)->setComment("");
+
+  iDesc.add<double>("probPion", 0.7)->setComment("");
+  iDesc.add<double>("probKaon", 0.2)->setComment("");
+  iDesc.add<double>("probProton", 0.1)->setComment("");
+
+  iDesc.add<double>("coolingFactor", 0.5)->setComment("");
+}
+
+void VertexTimeAlgorithmFromTracksPID::setEvent(edm::Event& iEvent, edm::EventSetup const&) {
+  // additional collections required for vertex-time calculation
+  trackMTDTimes_ = iEvent.get(trackMTDTimeToken_);
+  trackMTDTimeErrors_ = iEvent.get(trackMTDTimeErrorToken_);
+  trackMTDTimeQualities_ = iEvent.get(trackMTDTimeQualityToken_);
+  trackMTDMomenta_ = iEvent.get(trackMTDMomentumToken_);
+  trackMTDPathLengths_ = iEvent.get(trackMTDPathLengthToken_);
+}
+
+float VertexTimeAlgorithmFromTracksPID::trackTime(float const mass, float const mtdTime, float const mtdPathLength, float const mtdMomentum) const {
+  // speed of light, c = 29.9792458 cm/ns
+  return (mtdTime - mtdPathLength * std::sqrt(1.f + mass*mass/mtdMomentum/mtdMomentum) / 29.9792458f);
+}
+
+bool VertexTimeAlgorithmFromTracksPID::vertexTime(float& vtxTime, float& vtxTimeError, reco::Vertex const& vtx) const {
+  if(vtx.tracksSize() == 0){
+    return false;
+  }
+
+  auto const vtxTime_init = vtxTime;
+  auto const vtxTimeError_init = vtxTimeError;
+
+  double tsum = 0;
+  double wsum = 0;
+  double w2sum = 0;
+
+  double const a[3] = {probPion_, probKaon_, probProton_};
+
+  LOG << "vertexTimeFromTracks: vtx x=" << vtx.x() << " y=" << vtx.y() << " z=" << vtx.z() << " t=" << vtx.t();
+
+  std::vector<TrackInfo> v_trackInfo;
+  v_trackInfo.reserve(vtx.tracksSize());
+
+  // initial guess
+  for (auto trk = vtx.tracks_begin(); trk != vtx.tracks_end(); ++trk) {
+    auto const trkWeight = vtx.trackWeight(*trk);
+    if (trkWeight > minTrackVtxWeight_) {
+
+      auto const trkTimeQuality = trackMTDTimeQualities_[*trk];
+
+      if (trkTimeQuality >= minTrackTimeQuality_) {
+
+        auto const trkTime = trackMTDTimes_[*trk];
+        auto const trkTimeError = trackMTDTimeErrors_[*trk];
+        auto const trkPathLength = trackMTDPathLengths_[*trk];
+        auto const trkMomentum = trackMTDMomenta_[*trk];
+
+        v_trackInfo.emplace_back();
+        auto& trkInfo = v_trackInfo.back();
+
+        trkInfo.trkWeight = trkWeight;
+        trkInfo.trkTime = trkTime;
+        trkInfo.trkTimeError = trkTimeError;
+
+        if(trkPathLength > 0){
+          trkInfo.trkTimeHyp[0] = trackTime(massPion_, trkTime, trkPathLength, trkMomentum);
+          trkInfo.trkTimeHyp[1] = trackTime(massKaon_, trkTime, trkPathLength, trkMomentum);
+          trkInfo.trkTimeHyp[2] = trackTime(massProton_, trkTime, trkPathLength, trkMomentum);
+        } else {
+          trkInfo.trkTimeHyp[0] = 0.f;
+          trkInfo.trkTimeHyp[1] = 0.f;
+          trkInfo.trkTimeHyp[2] = 0.f;
+        }
+
+        auto const wgt = trkWeight / (trkTimeError*trkTimeError);
+        wsum += wgt;
+
+        for(uint j = 0; j < 3; ++j) {
+          tsum += wgt * trkInfo.trkTimeHyp[j] * a[j];
+        }
+
+        LOG << "vertexTimeFromTracks:     track"
+            << " pt=" << (*trk)->pt() << " eta=" << (*trk)->eta() << " phi=" << (*trk)->phi()
+            << " vtxWeight=" << trkWeight << " time=" << trkTime << " timeError=" << trkTimeError
+            << " timeQuality=" << trkTimeQuality << " pathLength=" << trkPathLength << " momentum=" << trkMomentum
+            << " timeHyp[pion]=" << trkInfo.trkTimeHyp[0] << " timeHyp[kaon]=" << trkInfo.trkTimeHyp[1]
+            << " timeHyp[proton]=" << trkInfo.trkTimeHyp[2];
+      }
+    }
+  }
+
+  if (wsum > 0) {
+
+    LOG << "vertexTimeFromTracks:   wsum = " << wsum << " tsum = " << tsum << " t0 = " << (wsum > 0 ? tsum/wsum : 0) << " trec = " << vtx.t();
+
+    auto t0 = tsum / wsum;
+    auto beta = 1./256.;
+    int nit = 0;
+    while ( (nit++) < 100 ) {
+      tsum = 0;
+      wsum = 0;
+      w2sum = 0;
+
+      for (auto const& trkInfo : v_trackInfo) {
+        double dt = trkInfo.trkTimeError;
+        double e[3] = {0,0,0};
+        double Z = exp(-beta * 0.5* 3.* 3.);
+        for(unsigned int j = 0; j < 3; j++){
+          auto const tpull =  (trkInfo.trkTimeHyp[j] - t0) / dt;
+          e[j] = exp(- 0.5 * beta * tpull * tpull);
+          Z += a[j] * e[j];
+        }
+
+        double wsum_trk = 0;
+        for(uint j = 0; j < 3; j++){
+          double wt = a[j] * e[j] / Z;
+          double w = wt * trkInfo.trkWeight / (dt * dt);
+          wsum_trk += w;
+          tsum += w * trkInfo.trkTimeHyp[j];
+        }
+
+        wsum += wsum_trk;
+        w2sum += wsum_trk * wsum_trk * (dt * dt) / trkInfo.trkWeight;
+      }
+
+      if (wsum < 1e-10) {
+        LOG << "vertexTimeFromTracks:   failed while iterating";
+        return false;
+      }
+
+      vtxTime = tsum / wsum;
+
+      LOG << "vertexTimeFromTracks:   iteration=" << nit << ", T= " << 1/beta << ", t=" << vtxTime << ", t-t0=" << vtxTime-t0;
+
+      if ((std::abs(vtxTime - t0) < 1e-4 / std::sqrt(beta)) and beta >= 1.) {
+
+        vtxTimeError = std::sqrt(w2sum) / wsum;
+
+        LOG << "vertexTimeFromTracks:   tfit = " << vtxTime << " +/- " << vtxTimeError << " trec = " << vtx.t() << ", iteration=" << nit;
+
+        return true;
+      }
+
+      if ((std::abs(vtxTime - t0) < 1e-3) and beta < 1.) {
+        beta = std::min(1., beta / coolingFactor_);
+      }
+
+      t0 = vtxTime;
+    }
+
+    LOG << "vertexTimeFromTracks: failed to converge";
+  }
+  else {
+    LOG << "vertexTimeFromTracks: has no track timing info";
+  }
+
+  vtxTime = vtxTime_init;
+  vtxTimeError = vtxTimeError_init;
+
+  return false;
+}
+
+DEFINE_EDM_VALIDATED_PLUGIN(VertexTimeAlgorithmBaseFactory, VertexTimeAlgorithmFromTracksPID, "VertexTimeAlgorithmFromTracksPID");

--- a/PrimaryVertexAnalyzer/plugins/VertexTimeAlgorithmFromTracksPID.h
+++ b/PrimaryVertexAnalyzer/plugins/VertexTimeAlgorithmFromTracksPID.h
@@ -1,0 +1,53 @@
+#ifndef usercode_PrimaryVertexAnalyzer_VertexTimeAlgorithmFromTracksPID_h
+#define usercode_PrimaryVertexAnalyzer_VertexTimeAlgorithmFromTracksPID_h
+
+#include "VertexTimeAlgorithmBase.h"
+
+#include "FWCore/Utilities/interface/EDGetToken.h"
+#include "DataFormats/Common/interface/ValueMap.h"
+
+class VertexTimeAlgorithmFromTracksPID : public VertexTimeAlgorithmBase {
+ public:
+  VertexTimeAlgorithmFromTracksPID(const edm::ParameterSet& conf, edm::ConsumesCollector& iC);
+  ~VertexTimeAlgorithmFromTracksPID() override = default;
+
+  static void fillPSetDescription(edm::ParameterSetDescription& iDesc);
+
+  void setEvent(edm::Event& iEvent, edm::EventSetup const& iSetup) override;
+
+  bool vertexTime(float& vtxTime, float& vtxTimeError, reco::Vertex const& vtx) const override;
+
+protected:
+  float trackTime(float const mass, float const mtdTime, float const mtdPathLength, float const mtdMomentum) const;
+
+  struct TrackInfo {
+    double trkWeight;
+    double trkTime;
+    double trkTimeError;
+    double trkTimeHyp[3];
+  };
+
+  edm::EDGetTokenT<edm::ValueMap<float>> const trackMTDTimeToken_;
+  edm::EDGetTokenT<edm::ValueMap<float>> const trackMTDTimeErrorToken_;
+  edm::EDGetTokenT<edm::ValueMap<float>> const trackMTDTimeQualityToken_;
+  edm::EDGetTokenT<edm::ValueMap<float>> const trackMTDMomentumToken_;
+  edm::EDGetTokenT<edm::ValueMap<float>> const trackMTDPathLengthToken_;
+
+  double const minTrackVtxWeight_;
+  double const minTrackTimeQuality_;
+  double const massPion_;
+  double const massKaon_;
+  double const massProton_;
+  double const probPion_;
+  double const probKaon_;
+  double const probProton_;
+  double const coolingFactor_;
+
+  edm::ValueMap<float> trackMTDTimes_;
+  edm::ValueMap<float> trackMTDTimeErrors_;
+  edm::ValueMap<float> trackMTDTimeQualities_;
+  edm::ValueMap<float> trackMTDMomenta_;
+  edm::ValueMap<float> trackMTDPathLengths_;
+};
+
+#endif

--- a/PrimaryVertexAnalyzer/plugins/VertexTimeProducer.cc
+++ b/PrimaryVertexAnalyzer/plugins/VertexTimeProducer.cc
@@ -1,70 +1,56 @@
-#include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/global/EDProducer.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
-#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/ParameterSet/interface/PluginDescription.h"
 #include "DataFormats/Common/interface/ValueMap.h"
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "DataFormats/VertexReco/interface/Vertex.h"
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
 
+#include "VertexTimeAlgorithmBaseFactory.h"
+#include "VertexTimeAlgorithmBase.h"
+
 #include <memory>
 #include <utility>
 
 #ifdef PVTX_DEBUG
-#define LOG edm::LogPrint("VertexTimeAnalyzer")
+#define LOG edm::LogPrint("VertexTimeProducer")
 #else
-#define LOG LogDebug("VertexTimeAnalyzer")
+#define LOG LogDebug("VertexTimeProducer")
 #endif
 
 class VertexTimeProducer : public edm::global::EDProducer<> {
 public:
   explicit VertexTimeProducer(edm::ParameterSet const&);
-  ~VertexTimeProducer() override = default;
 
   static void fillDescriptions(edm::ConfigurationDescriptions&);
 
 protected:
   void produce(edm::StreamID, edm::Event&, edm::EventSetup const&) const override;
 
-  float trackTime(float const mass, float const mtdTime, float const mtdPathLength, float const mtdMomentum) const;
-
-  bool vertexTimeFromTracks(float& vtxTime, float& vtxTimeError, reco::Vertex const& vtx, edm::ValueMap<float> const& vmapTrackMTDTimes, edm::ValueMap<float> const& vmapTrackMTDTimeErrors, edm::ValueMap<float> const& vmapTrackMTDTimeQualities, edm::ValueMap<float> const& vmapTrackMTDMomenta, edm::ValueMap<float> const& vmapTrackMTDPathLengths) const;
-
-  struct TrackInfo {
-    double trkWeight;
-    double trkTime;
-    double trkTimeError;
-    double trkTimeHyp[3];
-  };
-
   edm::EDGetTokenT<reco::VertexCollection> const vtxsToken_;
   bool const produceVertices_;
 
-  edm::EDGetTokenT<edm::ValueMap<float>> const trackMTDTimeToken_;
-  edm::EDGetTokenT<edm::ValueMap<float>> const trackMTDTimeErrorToken_;
-  edm::EDGetTokenT<edm::ValueMap<float>> const trackMTDTimeQualityToken_;
-  edm::EDGetTokenT<edm::ValueMap<float>> const trackMTDMomentumToken_;
-  edm::EDGetTokenT<edm::ValueMap<float>> const trackMTDPathLengthToken_;
-  float const minTrackVtxWeight_;
-  float const minTrackTimeQuality_;
+  std::unique_ptr<VertexTimeAlgorithmBase> const vertexTimeAlgorithmBase_;
 };
+
+namespace {
+  std::unique_ptr<VertexTimeAlgorithmBase> createVertexTimeAlgorithmBase(edm::ParameterSet const& pset, edm::ConsumesCollector&& iC) {
+    return VertexTimeAlgorithmBaseFactory::get()->create(pset.getParameter<std::string>("ComponentType"), pset, iC);
+  }
+}
 
 VertexTimeProducer::VertexTimeProducer(edm::ParameterSet const& iConfig) :
   vtxsToken_(consumes(iConfig.getParameter<edm::InputTag>("vertices"))),
   produceVertices_(iConfig.getParameter<bool>("produceVertices")),
-
-  trackMTDTimeToken_(consumes(edm::InputTag("trackExtenderWithMTD:generalTracktmtd"))),
-  trackMTDTimeErrorToken_(consumes(edm::InputTag("trackExtenderWithMTD:generalTracksigmatmtd"))),
-  trackMTDTimeQualityToken_(consumes(edm::InputTag("mtdTrackQualityMVA:mtdQualMVA"))),
-  trackMTDMomentumToken_(consumes(edm::InputTag("trackExtenderWithMTD:generalTrackp"))),
-  trackMTDPathLengthToken_(consumes(edm::InputTag("trackExtenderWithMTD:generalTrackPathLength"))),
-  minTrackVtxWeight_(iConfig.getParameter<double>("minTrackVtxWeight")),
-  minTrackTimeQuality_(iConfig.getParameter<double>("minTrackTimeQuality")) {
+  vertexTimeAlgorithmBase_(createVertexTimeAlgorithmBase(iConfig.getParameter<edm::ParameterSet>("algorithm"), consumesCollector())) {
 
   produces<edm::ValueMap<float>>("time");
   produces<edm::ValueMap<float>>("timeError");
@@ -78,12 +64,8 @@ void VertexTimeProducer::produce(edm::StreamID, edm::Event& iEvent, edm::EventSe
 
   auto const vtxsHandle = iEvent.getHandle(vtxsToken_);
 
-  // additional collections required for vertex-time calculation
-  auto const& trackMTDTimes = iEvent.get(trackMTDTimeToken_);
-  auto const& trackMTDTimeErrors = iEvent.get(trackMTDTimeErrorToken_);
-  auto const& trackMTDTimeQualities = iEvent.get(trackMTDTimeQualityToken_);
-  auto const& trackMTDMomenta = iEvent.get(trackMTDMomentumToken_);
-  auto const& trackMTDPathLengths = iEvent.get(trackMTDPathLengthToken_);
+  // initialise algorithm for vertex-time computation
+  vertexTimeAlgorithmBase_->setEvent(iEvent, iSetup);
 
   std::vector<float> vtxTimes;
   vtxTimes.reserve(vtxsHandle->size());
@@ -99,8 +81,8 @@ void VertexTimeProducer::produce(edm::StreamID, edm::Event& iEvent, edm::EventSe
 
   for (auto const& vtx : *vtxsHandle) {
     auto vtxTime(0.f), vtxTimeError(-1.f);
-    vertexTimeFromTracks(vtxTime, vtxTimeError, vtx,
-      trackMTDTimes, trackMTDTimeErrors, trackMTDTimeQualities, trackMTDMomenta, trackMTDPathLengths);
+
+    vertexTimeAlgorithmBase_->vertexTime(vtxTime, vtxTimeError, vtx);
 
     LOG << "Vertex #" << vtxTimes.size() << ": x=" << vtx.x() << ", y=" << vtx.y() << ": z=" << vtx.z() << ", t=" << vtxTime << ", tError=" << vtxTimeError;
 
@@ -158,175 +140,12 @@ void VertexTimeProducer::fillDescriptions(edm::ConfigurationDescriptions& descri
   edm::ParameterSetDescription desc;
   desc.add<edm::InputTag>("vertices", edm::InputTag("offlinePrimaryVertices"))->setComment("input collection of vertices");
   desc.add<bool>("produceVertices", false)->setComment("produce a collection of vertices with updated time and timeError");
-  desc.add<edm::InputTag>("tracks", edm::InputTag("generalTracks"))->setComment("input collection of tracks");
-  desc.add<double>("minTrackVtxWeight", -1.)->setComment("");
-  desc.add<double>("minTrackTimeQuality", -1.)->setComment("");
+
+  edm::ParameterSetDescription psd;
+  psd.addNode(edm::PluginDescription<VertexTimeAlgorithmBaseFactory>("ComponentType", true));
+  desc.add<edm::ParameterSetDescription>("algorithm", psd);
+
   descriptions.addWithDefaultLabel(desc);
-}
-
-float VertexTimeProducer::trackTime(float const mass, float const mtdTime, float const mtdPathLength, float const mtdMomentum) const {
-//!!  // speed of light, c = 29.9792458 cm/ns
-//!!  return (mtdTime - mtdPathLength * std::sqrt(1.f + mass*mass/mtdMomentum/mtdMomentum) / 29.9792458f);
-  double gammasq= 1. + mtdMomentum * mtdMomentum / (mass * mass);
-  double v = 2.99792458e1 * std::sqrt(1. - 1. / gammasq);  // cm / ns
-  return mtdTime - mtdPathLength / v;
-}
-
-bool VertexTimeProducer::vertexTimeFromTracks(float& t, float& tError, reco::Vertex const& vtx, edm::ValueMap<float> const& vmapTrackMTDTimes, edm::ValueMap<float> const& vmapTrackMTDTimeErrors, edm::ValueMap<float> const& vmapTrackMTDTimeQualities, edm::ValueMap<float> const& vmapTrackMTDMomenta, edm::ValueMap<float> const& vmapTrackMTDPathLengths) const {
-  if(vtx.tracksSize() == 0){
-    return false;
-  }
-
-  auto const t_init = t;
-  auto const tError_init = tError;
-
-  double tsum = 0;
-  double wsum = 0;
-  double w2sum = 0;
-
-  double const a[3] = {0.7, 0.2, 0.1};
-  double const cooling_factor = 0.5;
-  double const minquality = 0.0;
-  double const mintrkweight = 0.5;
-
-  double const massPion = 0.139570;
-  double const massKaon = 0.493677;
-  double const massProton = 0.938272;
-
-  bool const verbose = true;
-
-  if (verbose) {
-    LOG << "vertexTimeFromTracks: vtx x=" << vtx.x() << " y=" << vtx.y() << " z=" << vtx.z() << " t=" << vtx.t();
-  }
-
-  std::vector<TrackInfo> v_trackInfo;
-  v_trackInfo.reserve(vtx.tracksSize());
-
-  // initial guess
-  for (auto trk = vtx.tracks_begin(); trk != vtx.tracks_end(); ++trk) {
-    auto const trkWeight = vtx.trackWeight(*trk);
-    if (trkWeight > mintrkweight) {
-
-      auto const trkTimeQuality = vmapTrackMTDTimeQualities[*trk];
-
-      if (trkTimeQuality >= minquality) {
-
-        auto const trkTime = vmapTrackMTDTimes[*trk];
-        auto const trkTimeError = vmapTrackMTDTimeErrors[*trk];
-        auto const trkPathLength = vmapTrackMTDPathLengths[*trk];
-        auto const trkMomentum = vmapTrackMTDMomenta[*trk];
-
-        v_trackInfo.emplace_back();
-        auto& trkInfo = v_trackInfo.back();
-
-        trkInfo.trkWeight = trkWeight;
-        trkInfo.trkTime = trkTime;
-        trkInfo.trkTimeError = trkTimeError;
-
-        if(trkPathLength > 0){
-          trkInfo.trkTimeHyp[0] = trackTime(massPion, trkTime, trkPathLength, trkMomentum);
-          trkInfo.trkTimeHyp[1] = trackTime(massKaon, trkTime, trkPathLength, trkMomentum);
-          trkInfo.trkTimeHyp[2] = trackTime(massProton, trkTime, trkPathLength, trkMomentum);
-        } else {
-          trkInfo.trkTimeHyp[0] = 0.f;
-          trkInfo.trkTimeHyp[1] = 0.f;
-          trkInfo.trkTimeHyp[2] = 0.f;
-        }
-
-        auto const wgt = trkWeight / (trkTimeError*trkTimeError);
-        wsum += wgt;
-
-        for(uint j = 0; j < 3; ++j) {
-          tsum += wgt * trkInfo.trkTimeHyp[j] * a[j];
-        }
-
-        if (verbose) {
-          LOG << "vertexTimeFromTracks:     track"
-              << " pt=" << (*trk)->pt() << " eta=" << (*trk)->eta() << " phi=" << (*trk)->phi()
-              << " vtxWeight=" << trkWeight << " time=" << trkTime << " timeError=" << trkTimeError
-              << " timeQuality=" << trkTimeQuality << " pathLength=" << trkPathLength << " momentum=" << trkMomentum
-              << " timeHyp[pion]=" << trkInfo.trkTimeHyp[0] << " timeHyp[kaon]=" << trkInfo.trkTimeHyp[1]
-              << " timeHyp[proton]=" << trkInfo.trkTimeHyp[2];
-        }
-      }
-    }
-  }
-
-  if (wsum > 0) {
-
-    if(verbose) {
-      LOG << "vertexTimeFromTracks:   wsum = " << wsum << " tsum = " << tsum << " t0 = " << (wsum > 0 ? tsum/wsum : 0) << " trec = " << vtx.t();
-    }
-
-    auto t0 = tsum / wsum;
-    auto beta = 1./256.;
-    int nit = 0;
-    while ( (nit++) < 100 ) {
-      tsum = 0;
-      wsum = 0;
-      w2sum = 0;
-
-      for (auto const& trkInfo : v_trackInfo) {
-        double dt = trkInfo.trkTimeError;
-        double e[3] = {0,0,0};
-        double Z = exp(-beta * 0.5* 3.* 3.);
-        for(unsigned int j = 0; j < 3; j++){
-          auto const tpull =  (trkInfo.trkTimeHyp[j] - t0) / dt;
-          e[j] = exp(- 0.5 * beta * tpull * tpull);
-          Z += a[j] * e[j];
-        }
-
-        double wsum_trk = 0;
-        for(uint j = 0; j < 3; j++){
-          double wt = a[j] * e[j] / Z;
-          double w = wt * trkInfo.trkWeight / (dt * dt);
-          wsum_trk += w;
-          tsum += w * trkInfo.trkTimeHyp[j]; 
-        }
-
-        wsum += wsum_trk;
-        w2sum += wsum_trk * wsum_trk * (dt * dt) / trkInfo.trkWeight;
-      }
-
-      if (wsum < 1e-10) {
-        LOG << "vertexTimeFromTracks:   failed while iterating";
-        return false;
-      }
-
-      t = tsum / wsum;
-
-      if (verbose) {
-        LOG << "vertexTimeFromTracks:   iteration=" << nit << ", T= " << 1/beta << ", t=" << t << ", t-t0=" << t-t0;
-      }
-
-      if ((std::abs(t - t0) < 1e-4 / std::sqrt(beta)) and beta >= 1.) {
-
-        tError = std::sqrt(w2sum) / wsum;
-
-        if (verbose) {
-          LOG << "vertexTimeFromTracks:   tfit = " << t << " +/- " << tError << " trec = " << vtx.t() << ", iteration=" << nit;
-        }
-
-        return true;
-      }
-
-      if ((fabs(t - t0) < 1e-3) and beta < 1.) {
-        beta = std::min(1., beta / cooling_factor);
-      }
-
-      t0 = t;
-    }
-
-    LOG << "vertexTimeFromTracks: failed to converge";
-  }
-  else {
-    LOG << "vertexTimeFromTracks: has no track timing info";
-  }
-
-  t = t_init;
-  tError = tError_init;
-
-  return false;
 }
 
 DEFINE_FWK_MODULE(VertexTimeProducer);

--- a/PrimaryVertexAnalyzer/python/VertexTimeAlgorithmFromTracksPID_cfi.py
+++ b/PrimaryVertexAnalyzer/python/VertexTimeAlgorithmFromTracksPID_cfi.py
@@ -1,0 +1,24 @@
+import FWCore.ParameterSet.Config as cms
+
+VertexTimeAlgorithmFromTracksPID = cms.PSet(
+    ComponentType = cms.string('VertexTimeAlgorithmFromTracksPID'),
+
+    trackMTDTimeVMapTag = cms.InputTag('trackExtenderWithMTD:generalTracktmtd'),
+    trackMTDTimeErrorVMapTag = cms.InputTag('trackExtenderWithMTD:generalTracksigmatmtd'),
+    trackMTDTimeQualityVMapTag = cms.InputTag('mtdTrackQualityMVA:mtdQualMVA'),
+    trackMTDMomentumVMapTag = cms.InputTag('trackExtenderWithMTD:generalTrackp'),
+    trackMTDPathLengthVMapTag = cms.InputTag('trackExtenderWithMTD:generalTrackPathLength'),
+
+    minTrackVtxWeight = cms.double(0.5),
+    minTrackTimeQuality = cms.double(0.),
+
+    massPion = cms.double(0.139570),
+    massKaon = cms.double(0.493677),
+    massProton = cms.double(0.938272),
+
+    probPion = cms.double(0.7),
+    probKaon = cms.double(0.2),
+    probProton = cms.double(0.1),
+
+    coolingFactor = cms.double(0.5)
+)


### PR DESCRIPTION
This PR addresses one of the comments in #5, i.e.

> - `VertexTimeProducer`: the producer supports only the method corresponding to `PrimaryVertexAnalyzer4PU::vertex_time_from_tracks_pid`, and the latter algorithm is embedded in the producer. It should be possible to decouple producer and algorithm, in order to eventually have 1 producer and N algorithms (each algorithm would be a separate "plugin helper" class, choosable/configurable from the python configuration of the producer). Overall, `VertexTimeProducer` still requires some polishing (e.g. removal of "magic numbers") to conform to CMSSW coding rules.

In this update, the vertex-time producer and the algorithm are disentangled. This is done by using a "plugin factory" (i.e. `VertexTimeAlgorithmBaseFactory`) for the abstract base class `VertexTimeAlgorithmBase`.

The vertex-time computation is now implemented in a separate utility class called `VertexTimeAlgorithmFromTracksPID` which inherits from `VertexTimeAlgorithmBase`, and one instance of the algorithm runs inside the producer `VertexTimeProducer` (and is created there via the factory `VertexTimeAlgorithmBaseFactory`).

Other types of algorithms can now be implemented in a modular way following the approach implemented in this PR for `VertexTimeAlgorithmFromTracksPID` (any new vertex-time algorithm should be a class inheriting from `VertexTimeAlgorithmBase`). In principle, there should be no need to modify further the producer (`VertexTimeProducer`) nor the factory (`VertexTimeAlgorithmBaseFactory`).

The implementation borrows heavily from existing producer+factory examples in CMSSW, in particular see [`CkfTrackCandidateMakerBase`](https://github.com/cms-sw/cmssw/blob/4619cdcf976d6c174b2026f1a54342085ec7d52a/RecoTracker/CkfPattern/src/CkfTrackCandidateMakerBase.cc).

The validation of these changes was the same as that described in #5.